### PR TITLE
fix: skip child packages, such as git submodules

### DIFF
--- a/bin/rebase.js
+++ b/bin/rebase.js
@@ -129,6 +129,16 @@ walk('.', async function (err, pathname, dirent) {
     return false;
   }
 
+  // skip child directories that have their own package.json (such as git submodules)
+  const isChildDir = '.' !== pathname && dirent.isDirectory();
+  if (isChildDir) {
+    const submodulePkg = path.join(pathname, 'package.json');
+    const isNormalDir = await fs.access(submodulePkg).catch(Boolean);
+    if (!isNormalDir) {
+      return false;
+    }
+  }
+  
   if (!dirent.isFile()) {
     return;
   }


### PR DESCRIPTION
I'm refactoring an application into smaller chunks and as part of that process I'm leaving the existing code as git submodules, but the paths are already cleaned up relative to its own module.

I imagine that if anyone else were to have child packages within a package, those packages should be treated independently from their own root as well.