### PR TITLE
add '--all' to docs and add 'npm run version'

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ Upgrade existing `require`s and `import`s to the basetag way:
 npx basetag rebase
 ```
 
+Use `--all` to rebase child paths as well as parent paths:
+
+```bash
+# require('./bat') => require('$/baseball/bat')
+npx basetag rebase --all
+```
+
 ---
 
 > ⚠️ Unfortunately, npm does not like basetag very much

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lib/**.js"
   ],
   "scripts": {
-    "test": "node test/test.js"
+    "test": "node test/test.js",
+    "version": "npm version -m \"chore(release): bump to v%s\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- I needed `--all` today, which exists, but isn't in the readme
- next time you run `npm version x` it'll come out prettier
   ```
   chore(release): bump to vx.y.z
   ```